### PR TITLE
Fix skipped npm publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.check.outputs.version }}
-      should-publish: ${{ steps.check.outputs.should-publish }}
+      should_publish: ${{ steps.check.outputs.should_publish }}
 
     steps:
       - name: Checkout the CI-tested revision
@@ -83,7 +83,7 @@ jobs:
 
   publish:
     needs: check-version
-    if: needs.check-version.outputs.should-publish == 'true'
+    if: needs.check-version.outputs.should_publish == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -139,7 +139,7 @@ jobs:
       - publish
     if: >-
       needs.check-version.result == 'success' &&
-      needs.check-version.outputs.should-publish == 'true' &&
+      needs.check-version.outputs.should_publish == 'true' &&
       needs.publish.result == 'success'
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
Renames the publish-decision output to should_publish and updates its job conditions. This lets the publish and release jobs run when a version is not yet on npm.