### PR TITLE
Use reusable npm publishing workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,3 +29,11 @@ jobs:
 
       - name: Run tests
         run: vp test
+
+  publish:
+    needs: verify
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    uses: ./.github/workflows/publish.yml
+    permissions:
+      contents: write
+      id-token: write

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,9 @@
 name: Publish to npm
 
 on:
-  workflow_run:
-    workflows: [CI]
-    types: [completed]
+  # Call this from CI after its required jobs succeed. npm Trusted Publishing
+  # must be configured with the caller filename, ci.yml, not this filename.
+  workflow_call:
 
 permissions:
   contents: read
@@ -14,11 +14,6 @@ concurrency:
 
 jobs:
   check-version:
-    if: >-
-      github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.event == 'push' &&
-      github.event.workflow_run.head_branch == 'main' &&
-      github.event.workflow_run.head_repository.full_name == github.repository
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.check.outputs.version }}
@@ -29,12 +24,12 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
-          ref: ${{ github.event.workflow_run.head_sha }}
+          ref: ${{ github.sha }}
 
       - name: Verify the tested revision is still main
         id: revision
         env:
-          TESTED_SHA: ${{ github.event.workflow_run.head_sha }}
+          TESTED_SHA: ${{ github.sha }}
         run: |
           if [ "$(git rev-parse HEAD)" != "$TESTED_SHA" ]; then
             echo "Checked out revision does not match the successful CI run" >&2
@@ -93,7 +88,7 @@ jobs:
       - name: Checkout the CI-tested revision
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.workflow_run.head_sha }}
+          ref: ${{ github.sha }}
 
       - name: Setup Vite+
         uses: voidzero-dev/setup-vp@v1.17.0
@@ -103,6 +98,9 @@ jobs:
 
       - name: Install dependencies
         run: vp install
+
+      - name: Pack the library
+        run: vp pack
 
       - name: Verify npm supports trusted publishing
         run: |
@@ -121,7 +119,7 @@ jobs:
 
       - name: Reconfirm the published revision
         env:
-          TESTED_SHA: ${{ github.event.workflow_run.head_sha }}
+          TESTED_SHA: ${{ github.sha }}
         run: |
           git fetch --no-tags origin main
 
@@ -151,7 +149,7 @@ jobs:
         with:
           tag_name: v${{ needs.check-version.outputs.version }}
           name: v${{ needs.check-version.outputs.version }}
-          target_commitish: ${{ github.event.workflow_run.head_sha }}
+          target_commitish: ${{ github.sha }}
           draft: false
           prerelease: false
           generate_release_notes: true


### PR DESCRIPTION
Replaces the detached `workflow_run` publisher with the reusable workflow called from the final CI job. Publishing now waits on `verify`, runs only for successful pushes to `main`, retains the stale-revision and version guards, and builds the package before publishing.